### PR TITLE
Update support button link

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -21,7 +21,7 @@
   "topbarLinks": [
     {
       "name": "Support",
-      "url": "mailto:support@relay.link"
+      "url": "https://support.relay.link/en/"
     }
   ],
   "topbarCtaButton": {


### PR DESCRIPTION
Update the support button to point to https://support.relay.link/en/ 
Details documented in this ticket  https://linear.app/reservoir/issue/RELAY-6865/update-button-link-to-correct-support-page-on-relay-site