### PR TITLE
Clarify signatureChainId behavior in Hyperliquid docs

### DIFF
--- a/references/api/api_guides/hyperliquid-support.mdx
+++ b/references/api/api_guides/hyperliquid-support.mdx
@@ -560,7 +560,7 @@ The response includes two steps that must be executed in order.
 The first step (`id: authorize`) requires signing an EIP-712 message that maps the nonce to the request ID. This signature can be executed on any EVM chain.
 
 <Note>
-  **Chain ID Override Required**: The API returns Ethereum mainnet (chainId: 1) by default. You must override both `item.data.sign.domain.chainId` and `item.data.post.body.signatureChainId` to match the user's active chain ID (Base, Optimism, etc.) or your preferred chain ID. The signature submitted to the deposit step must use the same modified chainId.
+  **Chain ID Override Recommended**: The `signatureChainId` and `domain.chainId` fields are used for EIP-712 signature authorization only — they do not affect fund routing. The `destinationChainId` in your quote request determines where funds are delivered. The API returns Ethereum mainnet (chainId: 1) by default. We recommend overriding both `item.data.sign.domain.chainId` and `item.data.post.body.signatureChainId` to match the user's active chain ID (Base, Optimism, etc.) for wallet and signature correctness.
 </Note>
 
 Example authorize step response:


### PR DESCRIPTION
## Summary
- Clarifies that `signatureChainId` / `domain.chainId` are for EIP-712 signature authorization only and do not affect fund routing
- Changes wording from "Override Required" to "Override Recommended"
- Adds note that `destinationChainId` in the quote request is what controls fund delivery

## Context
- Customer reported successful swaps without overriding `signatureChainId` ([Intercom](https://app.intercom.com/a/inbox/b09ps4q8/inbox/admin/8321729/conversation/215473815586868))
- Engineering confirmed via [SE-1616](https://linear.app/relayprotocol/issue/SE-1616) that the field is only used in the authorize/nonce-mapping signing flow, not routing

## Test plan
- [ ] Verify the Note callout renders correctly on the docs site
- [ ] Confirm wording aligns with engineering's findings in SE-1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)