### PR TITLE
[PLATF-5892] Document /execute simulation error details

### DIFF
--- a/features/gasless-execution.mdx
+++ b/features/gasless-execution.mdx
@@ -444,6 +444,92 @@ In this example use case you want to execute a gasless Relay quote with the [exe
     Refer to the [quickstart guide](/references/api/quickstart#status-lifecycle) for more information on how to monitor the status of a transaction.
 </Steps>
 
+## Handling simulation errors
+
+Relay simulates `/execute` raw calls before submission. If the simulation reverts, the API returns `400` with a decoded error label, a message, the `requestId`, and trace details when Relay can decode the revert path.
+
+```typescript
+type ExecuteSimulationErrorResponse = {
+  error: string;
+  message: string;
+  requestId: string;
+  details?: SimulationErrorDetails;
+};
+
+type SimulationErrorDetails = {
+  topLevel: SimulationErrorFrame;
+  innermost: SimulationErrorFrame;
+  path: SimulationErrorFrame[];
+  revert: {
+    type: "errorString" | "panic" | "customError" | "unknownCustomError" | "empty";
+    label: string;
+    message: string;
+    selector?: string;
+    name?: string;
+    args?: Record<string, string>;
+    rawArgsHex?: string;
+  };
+};
+
+type SimulationErrorFrame = {
+  type: string;
+  address?: string;
+  contract?: string;
+  function?: string;
+  selector?: string;
+  error?: string;
+  revertReason?: string;
+  gasUsed?: string;
+};
+```
+
+Use **`error`** and **`message`** for integration handling, and include **`requestId`** when contacting Relay support. Use **`details.innermost`** and **`details.revert`** to identify the contract, function selector, and revert data that caused the simulation failure.
+
+```json Response
+{
+  "error": "INVALID_SIGNATURE",
+  "message": "Invalid signature",
+  "requestId": "0x887091202256e66960493eb09c410188307cc734c919e89696b3ae9993a7fa1d",
+  "details": {
+    "topLevel": {
+      "type": "CALL",
+      "address": "0xca11bde05977b3631167028862be2a173976ca11",
+      "contract": "Multicall3",
+      "function": "Multicall3.aggregate3Value"
+    },
+    "innermost": {
+      "type": "CALL",
+      "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
+      "contract": "Permit2",
+      "selector": "0xda9c8680",
+      "error": "execution reverted"
+    },
+    "path": [
+      {
+        "type": "CALL",
+        "contract": "Multicall3",
+        "function": "Multicall3.aggregate3Value"
+      },
+      {
+        "type": "CALL",
+        "contract": "Permit2",
+        "selector": "0xda9c8680",
+        "error": "execution reverted"
+      }
+    ],
+    "revert": {
+      "type": "customError",
+      "label": "INVALID_SIGNATURE",
+      "message": "Invalid signature",
+      "selector": "0x8baa579f",
+      "name": "InvalidSignature"
+    }
+  }
+}
+```
+
+If Relay cannot map a custom error selector to a known contract error, the response uses a label like `UNKNOWN_CUSTOM_ERROR_0x34ceaf9e` and includes **`rawArgsHex`** when encoded revert arguments are available.
+
 ### More Use Cases
 
 <AccordionGroup>

--- a/references/api/changelog.mdx
+++ b/references/api/changelog.mdx
@@ -3,6 +3,10 @@ title: "API Changelog"
 description: "Record of breaking changes, deprecations, and notable additions to the Relay API"
 ---
 
+## 2026-05-20 — Decoded `/execute` simulation errors
+
+**Behavior change** — `POST /execute`: raw-call simulation failures now return a decoded `error` label, `message`, `requestId`, and optional `details` object when Relay can decode the revert trace. The `details` object includes the top-level frame, innermost reverting frame, full reverting path, and decoded revert data for both subsidized and non-subsidized gasless execution flows.
+
 ## 2026-05-15 — More specific `failReason` values on request status
 
 **Added** — `GET /intents/status/v3`: the response `failReason` enum gains `TRANSACTION_TOO_LARGE`, returned when the serialized fill transaction exceeded the origin chain or RPC payload size limit. The enum also gains `SOLVER_BALANCE_TOO_LOW`, returned when the solver could not construct or send the fill because its source-side balance (or available UTXOs) was insufficient.


### PR DESCRIPTION
## Summary

- Document the `/execute` simulation error response shape in the Gasless Execution guide.
- Add the `ExecuteSimulationErrorResponse` / `SimulationErrorDetails` interface fields, including decoded revert trace details.
- Add an API changelog entry for decoded simulation errors on subsidized and non-subsidized gasless execution flows.

## Validation

- `git diff --check`
- No local docs build was run because this repo does not include a `package.json` or repo-local build script.