### PR TITLE
Remove all Sui references from docs

### DIFF
--- a/features/app-fees.mdx
+++ b/features/app-fees.mdx
@@ -38,7 +38,7 @@ App fees are supported on the following transaction types:
 
 | Transaction Type | Supported |
 |---|---|
-| Swaps (cross-chain) | ✅ All chain combinations (EVM, SVM, SUI, BTC) |
+| Swaps (cross-chain) | ✅ All chain combinations (EVM, SVM, BTC) |
 | Swaps (same-chain) | ✅ See chain-specific notes below |
 | Bridges | ✅ |
 | Calls | ✅ |
@@ -52,8 +52,6 @@ App fees are supported on the following transaction types:
 **EVM (same-chain):** Fully supported. Fees can be collected from the input currency, the output currency, or via a parallel swap to USDC.
 
 **SVM (same-chain):** Supported with input-currency collection only. Output-currency fee collection is not available — this applies to all output currencies, not just SOL. If the input currency is not a solver-held currency, the fee is collected via a secondary swap into USDC.
-
-**SUI (same-chain):** Supported with input-currency collection only. No output-currency collection or parallel swap fallback. App fees will only be collected when the input is a solver-held currency.
 
 **Cross-chain (all combinations):** Fully supported. Same-chain limitations do not apply to cross-chain swaps — fees are calculated based on the solver's deposit currency on the origin chain.
 

--- a/references/protocol/guides/third-party-oracle.mdx
+++ b/references/protocol/guides/third-party-oracle.mdx
@@ -81,7 +81,6 @@ The current VM attestor implementation supports:
 - `bitcoin-vm`
 - `hyperliquid-vm`
 - `lighter-vm`
-- `sui-vm`
 - `tron-vm`
 
 Which chains are enabled is controlled by the selected environment config:

--- a/references/relay-kit/sdk/adapters.mdx
+++ b/references/relay-kit/sdk/adapters.mdx
@@ -9,7 +9,7 @@ An adapter is a function that takes parameters and returns an object that adhere
 
 | Property                   | Description                                                                                     | Required |
 | -------------------------- | ----------------------------------------------------------------------------------------------- | -------- |
-| **vmType**                    | A string representing a supported vmType (`evm`  `svm`  `bvm`  `suivm` `tvm` `lvm`)                                                   | ✅       |
+| **vmType**                    | A string representing a supported vmType (`evm`  `svm`  `bvm`  `tvm` `lvm`)                                                   | ✅       |
 | **getChainId**                | An async function that returns a chain id                                                                                              | ✅       |
 | **handleSignMessageStep**     | An async function that given a signature step item and a step generates a signature                                                                                              | ✅       |
 | **handleSendTransactionStep** | An async function that given a chain id, a transaction step item and a step returns a transaction hash                                                                                              | ✅       |
@@ -34,8 +34,6 @@ The following adapters are officially maintained and developed by the Relay team
 [Viem Adapter](https://github.com/relayprotocol/relay-kit/blob/main/packages/sdk/src/utils/viemWallet.ts): This adapter is the default one used when no adapter is provided. You can also import it yourself to convert any viem wallet client into an adapted wallet ready to be used in the sdk.
 
 [Ethers Adapter](https://github.com/relayprotocol/relay-kit/tree/main/packages/relay-ethers-wallet-adapter): If your application uses ethers then you'll need this adapter to use the SDK. You'll still need to install viem as that's required for polling transactions but you can pass in your ethers signer to submit transactions and sign messages.
-
-[Sui Adapter](https://github.com/relayprotocol/relay-kit/tree/main/packages/relay-sui-wallet-adapter): This adapter gives the sdk the ability to submit transactions to the Sui blockchain. Under the hood it uses the [@mysten/sui](https://www.npmjs.com/package/@mysten/sui) sdk.
 
 [Tron Adapter](https://github.com/relayprotocol/relay-kit/tree/main/packages/relay-tron-wallet-adapter): This adapter gives the sdk the ability to submit transactions to the Tron blockchain. Under the hood it uses the [tronweb](https://www.npmjs.com/package/tronweb) sdk.
 
@@ -170,51 +168,6 @@ getClient().actions.execute({
 ```
 
 
-```typescript Sui expandable
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client'
-import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519'
-import { getClient, Execute, getQuote } from "@relayprotocol/relay-sdk"
-import { adaptSuiWallet } from '@relayprotocol/relay-sui-wallet-adapter'
-
-// Create a connection to Sui mainnet
-const rpcUrl = getFullnodeUrl('mainnet')
-const suiClient = new SuiClient({ url: rpcUrl })
-
-const keypair = new Ed25519Keypair()
-const walletAddress = keypair.toSuiAddress()
-
-const adaptedWallet = adaptSuiWallet(
-  walletAddress,
-  103665049, //chain id that Relay uses to identify Sui 
-  suiClient,
-  async (tx) => {
-   const result = await suiClient.signAndExecuteTransaction({
-      transaction: tx,
-      signer: keypair,
-      requestType: 'WaitForLocalExecution',
-      options: {
-        showEffects: true,
-      }
-    });
-
-    return result
-  }
-)
-
-const options = ... //define this based on getQuote options
-
-const quote = await getClient().actions.getQuote(options)
-
-getClient().actions.execute({
-  quote,
-  wallet: adaptedWallet,
-  onProgress: ({steps, fees, breakdown, currentStep, currentStepItem, txHashes, details}) => {
-    //custom handling
-  },
-    ...
-})
-
-```
 ```typescript Tron
 import { TronWallet } from 'tronweb'
 import { getClient, Execute, getQuote } from "@relayprotocol/relay-sdk"

--- a/use-cases/bridging.mdx
+++ b/use-cases/bridging.mdx
@@ -9,7 +9,7 @@ Relay enables instant bridging (deposits & withdrawals) on supported chains. By 
 
 **Instant Cross-chain Onboarding** - Relay's median bridge time is 2.7 seconds across chains.
 
-**Multi-VM Support** - Relay Supports major EVM chains, as well as Bitcoin, Solana, Sui, Tron, Eclipse, and more.
+**Multi-VM Support** - Relay Supports major EVM chains, as well as Bitcoin, Solana, Tron, Eclipse, and more.
 
 **Deposit Addresses** - [Deposit Addresses](/features/deposit-addresses) allow users to onboard onto any chain via a transfer on any network. This makes it seamless for users to onboard from centralized exchanges or without connecting a wallet.
 

--- a/use-cases/cross-chain-swaps.mdx
+++ b/use-cases/cross-chain-swaps.mdx
@@ -11,7 +11,7 @@ Relay enables both same and cross-chain swaps on supported chains. We couple rob
 
 **Instant Cross-chain Swaps** - Relay's median bridge time is 2.7 seconds across chains.
 
-**Multi-VM Support** - Relay Supports major EVM chains, as well as Bitcoin, Solana, Sui, Tron, Eclipse, and more.
+**Multi-VM Support** - Relay Supports major EVM chains, as well as Bitcoin, Solana, Tron, Eclipse, and more.
 
 **Gasless Support** - Relay supports gasless swaps via native support of 4337 account abstraction, 7702 support, and gasless permit execution (3009 and 2612)
 


### PR DESCRIPTION
Sui support has been disabled for months. Removes mentions from adapters, app-fees, bridging, cross-chain-swaps, and third-party-oracle.