### PR TITLE
Polish quote error docs

### DIFF
--- a/references/api/api_core_concepts/handling-errors.mdx
+++ b/references/api/api_core_concepts/handling-errors.mdx
@@ -26,9 +26,9 @@ These are known validation and routing issues that developers should gracefully 
 | `NO_INTERNAL_SWAP_ROUTES_FOUND`               | No valid swap route exists internally for the selected token pair.         |
 | `NO_QUOTES`                                   | No available quotes for the given parameters.                              |
 | `NO_SWAP_ROUTES_FOUND`                        | No route was found to fulfill the quote request with the given parameters. |
-| `REQUEST_TIMED_OUT`                           | An upstream RPC provider timed out before returning a result. Safe to retry. |
-| `RPC_HTTP_ERROR`                              | A downstream RPC provider returned a transient infrastructure error. Safe to retry. |
+| `REQUEST_TIMED_OUT`                           | An upstream RPC provider timed out before returning a result.              |
 | `ROUTE_TEMPORARILY_RESTRICTED`                | This route is temporarily restricted due to high traffic or throttling.    |
+| `RPC_HTTP_ERROR`                              | An upstream RPC provider returned a transient infrastructure error.        |
 | `SANCTIONED_CURRENCY`                         | The token involved in the transaction is on a sanctions list.              |
 | `SANCTIONED_WALLET_ADDRESS`                   | The sender or recipient wallet address is sanctioned or blacklisted.       |
 | `SWAP_IMPACT_TOO_HIGH`                        | The swap's price impact exceeds acceptable thresholds.                     |

--- a/references/api/changelog.mdx
+++ b/references/api/changelog.mdx
@@ -5,7 +5,7 @@ description: "Record of breaking changes, deprecations, and notable additions to
 
 ## 2026-06-05 — Upstream RPC failures no longer reported as `DESTINATION_TX_FAILED`
 
-**Behavior change** — `POST /quote/v2`: quote attempts that fail because an upstream RPC provider returns a transient infrastructure error (proxy timeout, pool-acquire failure, or any negative JSON-RPC code with empty revert data) now return `errorCode: "REQUEST_TIMED_OUT"` when the upstream message indicates a timeout, or `errorCode: "RPC_HTTP_ERROR"` for other transient RPC failures. Previously these were misclassified as `errorCode: "DESTINATION_TX_FAILED"`, which incorrectly suggested an on-chain revert and was treated as non-retryable. `DESTINATION_TX_FAILED` continues to be returned for genuine destination reverts where the RPC provides real revert data. Both new codes are retryable — see [Handling Quote Errors](/references/api/api_core_concepts/handling-errors).
+**Behavior change** — `POST /quote/v2`: quote attempts that fail because of a transient upstream RPC error now return `errorCode: "REQUEST_TIMED_OUT"` on timeout or `errorCode: "RPC_HTTP_ERROR"` for other transient RPC failures. Previously these were misclassified as `errorCode: "DESTINATION_TX_FAILED"`, which suggested an on-chain revert and was treated as non-retryable. `DESTINATION_TX_FAILED` is now returned only for genuine destination reverts. Both new codes are retryable — see [Handling Quote Errors](/references/api/api_core_concepts/handling-errors).
 
 ## 2026-05-28 — Bitcoin deposits enter `pending` from mempool
 


### PR DESCRIPTION
Polishes the merged quote error docs follow-up by trimming internal changelog details, restoring expected-error table ordering, and removing redundant retry text from table rows. Verification: git diff --check.