### PR TITLE
Expand and clarify fee structure documentation

### DIFF
--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -107,7 +107,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
 
 4. **App Fees**
 
-   Fees added on top of a Relay by the integrator.
+   Fees added on top of a Relay quote.
 
 If you are interested in learning how app fees work, and how you can add them to your quotes please check out our [App Fees Doc](/features/app-fees).
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -152,7 +152,7 @@ When displaying fees to users, we recommend mapping the `expandedPriceImpact` fi
 
 Integrators with [Fee Sponsorship](/features/fee-sponsorship) enabled can subsidize fees for their users. By default, setting **`subsidizeFees`** to `true` sponsors all fee components.
 
-For more granular control, use the **`sponsoredFeeComponents`** parameter in the quote request to choose which specific fee components to sponsor. This allows you to sponsor some fees (e.g. execution and relay fees) while letting the user pay others (e.g. swap fees). 
+For more granular control, use the **`sponsoredFeeComponents`** parameter in the quote request to choose which specific fee components to sponsor. This allows you to sponsor some fees (e.g. execution and relay fees) while letting the user pay others (e.g. swap fees).
 
 <Warning>
 Deposit addresses do not support `sponsoredFeeComponents`.

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -27,14 +27,14 @@ In any given token swap or bridge powered by Relay, there are four potential fee
 
    A flat basis point fee charged for using the Relay API gateway and related services, including via the Relay.link frontend.
 
-   <table className="relay-table">
+   <table className="relay-table" style={{tableLayout: "fixed", width: "100%"}}>
      <thead>
        <tr>
-         <th>Standard Fees</th>
-         <th>Token Bridge & Same-Chain Wrap/Unwrap</th>
-         <th>Stablecoin Swap</th>
-         <th>Major Swap</th>
-         <th>Minor Swap</th>
+         <th style={{width: "20%"}}>Standard Fees</th>
+         <th style={{width: "20%"}}>Token Bridge & Same-Chain Wrap/Unwrap</th>
+         <th style={{width: "20%"}}>Stablecoin Swap</th>
+         <th style={{width: "20%"}}>Major Swap</th>
+         <th style={{width: "20%"}}>Minor Swap</th>
        </tr>
      </thead>
      <tbody>
@@ -57,14 +57,14 @@ In any given token swap or bridge powered by Relay, there are four potential fee
 
    The revenue share cannot be used to discount the Relay product to end users.
 
-   <table className="relay-table">
+   <table className="relay-table" style={{tableLayout: "fixed", width: "100%"}}>
      <thead>
        <tr>
-         <th>Revenue Share Volume Tier* (U.S. Dollars)</th>
-         <th>Token Bridge & Same-Chain Wrap/Unwrap</th>
-         <th>Stablecoin Swap</th>
-         <th>Major Swap</th>
-         <th>Minor Swap</th>
+         <th style={{width: "20%"}}>Revenue Share Volume Tier* (U.S. Dollars)</th>
+         <th style={{width: "20%"}}>Token Bridge & Same-Chain Wrap/Unwrap</th>
+         <th style={{width: "20%"}}>Stablecoin Swap</th>
+         <th style={{width: "20%"}}>Major Swap</th>
+         <th style={{width: "20%"}}>Minor Swap</th>
        </tr>
      </thead>
      <tbody>

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -90,7 +90,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    **Relay Transaction Types:**
    - **Token Bridge:** a token bridge transaction. Examples:
      - USDC on Arbitrum to USDC on Base
-   - **Same-chain wrap/unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:
+   - **Same-Chain Wrap/Unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:
      - ETH to WETH on Ethereum
      - SOL to WSOL on Solana
      - POL to WPOL on Polygon

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -85,7 +85,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      </tbody>
    </table>
 
-   _* The Revenue Share Volume Tier is calculated based on aggregate U.S. dollar value of transactions, trailing 30 days._
+   _* The Revenue Share Volume Tier is calculated based on the aggregate U.S. dollar value of the transactions for the trailing 30 days._
 
    **Relay Fee Categories:**
    - **Same token bridging:** a token bridge transaction with the same asset and no swap. Examples:

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fee Structure"
-description: "Learn about Relay's fee structures"
+description: "Learn about Relay's fee structure"
 ---
 
 In any given token swap or bridge powered by Relay, there are four potential fees:

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -101,7 +101,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME (each, a "Major Token"), and between any Major Token and any Major Stablecoin. Examples:
      - ETH to POL on Polygon
      - ETH on Ethereum to SOL on Solana
-   - **Minor swaps:** same-chain or crosschain token swaps between any pair of tokens that are not a Major Stablecoin or Major Token. Examples:
+   - **Minor swaps:** same-chain or cross-chain token swaps between any pair of tokens that are not a Major Stablecoin or Major Token. Examples:
      - LINK to UNI on Ethereum
      - AVAX on Avalanche to Aster on BNB Chain
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -48,7 +48,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      </tbody>
    </table>
 
-   Relay customers can receive a revenue share on the Relay Fee. The revenue share varies by asset pair type and volume tier, as detailed below. To qualify, customers must:
+   Relay integrators can receive a revenue share on the Relay Fee. The revenue share varies by asset pair type and volume tier, as detailed below. To qualify, integrators must:
 
    1. Pass an API key in the Relay quote
    2. Complete Know Your Business (KYB) verification

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -88,7 +88,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    _* The Revenue Share Volume Tier is calculated based on the aggregate U.S. dollar value of the transactions for the trailing 30 days._
 
    **Relay Transaction Types:**
-   - **Token Bridging:** a token bridge transaction. Examples:
+   - **Token Bridge:** a token bridge transaction. Examples:
      - USDC on Arbitrum to USDC on Base
    - **Same-chain wrap/unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:
      - ETH to WETH on Ethereum

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -31,7 +31,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      <thead>
        <tr>
          <th>Standard Fees</th>
-         <th>Token Bridge</th>
+         <th>Token Bridge & Same-Chain Wrap/Unwrap</th>
          <th>Stablecoin Swap</th>
          <th>Major Swap</th>
          <th>Minor Swap</th>

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -101,7 +101,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME (each, a "Major Token"), and between any Major Token and any Major Stablecoin. Examples:
      - ETH to POL on Polygon
      - ETH on Ethereum to SOL on Solana
-   - **Minor swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:
+   - **Minor swaps:** same-chain or crosschain token swaps between any pair of tokens that are not a Major Stablecoin or Major Token. Examples:
      - LINK to UNI on Ethereum
      - AVAX on Avalanche to Aster on BNB Chain
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -30,11 +30,11 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    <table className="relay-table" style={{tableLayout: "fixed", width: "100%"}}>
      <thead>
        <tr>
-         <th style={{width: "20%"}}>Standard Fees</th>
-         <th style={{width: "20%"}}>Token Bridge & Same-Chain Wrap/Unwrap</th>
-         <th style={{width: "20%"}}>Stablecoin Swap</th>
-         <th style={{width: "20%"}}>Major Swap</th>
-         <th style={{width: "20%"}}>Minor Swap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Standard Fees</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Token Bridge & Same-Chain Wrap/Unwrap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Stablecoin Swap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Major Swap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Minor Swap</th>
        </tr>
      </thead>
      <tbody>
@@ -60,11 +60,11 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    <table className="relay-table" style={{tableLayout: "fixed", width: "100%"}}>
      <thead>
        <tr>
-         <th style={{width: "20%"}}>Revenue Share Volume Tier* (U.S. Dollars)</th>
-         <th style={{width: "20%"}}>Token Bridge & Same-Chain Wrap/Unwrap</th>
-         <th style={{width: "20%"}}>Stablecoin Swap</th>
-         <th style={{width: "20%"}}>Major Swap</th>
-         <th style={{width: "20%"}}>Minor Swap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Revenue Share Volume Tier* (U.S. Dollars)</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Token Bridge & Same-Chain Wrap/Unwrap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Stablecoin Swap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Major Swap</th>
+         <th style={{width: "20%", verticalAlign: "top"}}>Minor Swap</th>
        </tr>
      </thead>
      <tbody>

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -98,7 +98,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    - **Stablecoin swaps:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD (each, a "Major Stablecoin"). Examples:
      - USDC to USDT on Ethereum
      - USDC on Optimism to USDT on Solana
-   - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME, and between any major token and any major stablecoin. Examples:
+   - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME (each, a "Major Token"), and between any Major Token and any Major Stablecoin. Examples:
      - ETH to WETH on Polygon
      - ETH on Ethereum to SOL on Solana
    - **Minor swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -88,7 +88,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    _* The Revenue Share Volume Tier is calculated based on the aggregate U.S. dollar value of the transactions for the trailing 30 days._
 
    **Relay Transaction Types:**
-   - **Token Bridging:** a token bridge transaction with the same asset and no swap. Examples:
+   - **Token Bridging:** a token bridge transaction. Examples:
      - USDC on Arbitrum to USDC on Base
    - **Same-chain wrap/unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:
      - ETH to WETH on Ethereum

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -98,10 +98,10 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    - **Stablecoin swaps:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD (each, a "Major Stablecoin"). Examples:
      - USDC to USDT on Ethereum
      - USDC on Optimism to USDT on Solana
-   - **Major token swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME, and between any major token and any major stablecoin. Examples:
+   - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME, and between any major token and any major stablecoin. Examples:
      - ETH to WETH on Polygon
      - ETH on Ethereum to SOL on Solana
-   - **Minor token swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:
+   - **Minor swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:
      - LINK to UNI on Ethereum
      - AVAX on Avalanche to Aster on BNB Chain
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -1,74 +1,116 @@
 ---
-title: "Relay Fees"
-description: "Learn about Relay fees"
+title: "Fee Structure"
+description: "Learn about Relay's fee structures"
 ---
 
-In any given Relay there are four potential fees:
+In any given token swap or bridge powered by Relay, there are four potential fees:
 
 1. **Execution Fees**
 
-   Fees to cover execution costs including network gas on the origin and/or destination chain.
-   - Fill gas estimate (and origin gas estimate for gasless transactions)
-   - $0.02 flat fee
+   Covers execution costs including network gas on the origin and/or destination chain, and includes:
+   - $0.02 flat fee — always included
+   - Destination (fill) gas estimate — always included, covers transaction fulfillment on the destination chain
+   - Origin gas estimate — only included for gasless transactions, covers transaction submission on the origin chain on the user's behalf
+
+   For regular (non-gasless) transactions, the user pays origin gas directly from their own wallet to the network — it's not part of Relay's fee.
+
 2. **Swap Fees**
 
-   Fees to liquidity providers that facilitate cross-asset and cross-chain token swaps.
+   Covers payments to liquidity providers that facilitate cross-asset and cross-chain token swaps, and includes:
    - DEX fees
    - DEX swap impact
    - Solver cross-chain rebalancing fees
+
+   Note: Hyperliquid charges a $1 activation fee for new deposits. Relay cannot change this fee — it is passed through to users.
+
 3. **Relay Fees**
 
-   A flat basis point fee charged for using the Relay API gateway and related services. The fee varies by asset pair type and volume tier. An API key is required for the volume based discounts to take effect.
+   A flat basis point fee charged for using the Relay API gateway and related services, including via the Relay.link frontend.
 
    <table className="relay-table">
      <thead>
        <tr>
-         <th>Volume Tier</th>
-         <th>Same Token Bridge</th>
-         <th>Stablecoin Swaps</th>
-         <th>Major Swaps</th>
-         <th>Minor Swaps</th>
+         <th>Standard Fees</th>
+         <th>Token Bridge</th>
+         <th>Stablecoin Swap</th>
+         <th>Major Swap</th>
+         <th>Minor Swap</th>
        </tr>
      </thead>
      <tbody>
        <tr>
-         <td>{'< $10M'}</td>
+         <td>Relay Fee charged to end users</td>
          <td>0.00%</td>
          <td>0.01%</td>
          <td>0.06%</td>
          <td>0.15%</td>
        </tr>
+     </tbody>
+   </table>
+
+   Relay customers can receive a revenue share on the Relay Fee. The revenue share varies by asset pair type and volume tier, as detailed below. To qualify, customers must:
+
+   1. Pass an API key in the Relay quote
+   2. Complete Know Your Business (KYB) verification
+   3. Exceed $10,000,000 in aggregate U.S. dollar volume over a trailing 30-day period
+   4. Provide an EVM wallet address to receive revenue share
+
+   The revenue share cannot be used to discount the Relay product to end users.
+
+   <table className="relay-table">
+     <thead>
+       <tr>
+         <th>Revenue Share Volume Tier* (U.S. Dollars)</th>
+         <th>Token Bridge & Same-Chain Wrap/Unwrap</th>
+         <th>Stablecoin Swap</th>
+         <th>Major Swap</th>
+         <th>Minor Swap</th>
+       </tr>
+     </thead>
+     <tbody>
        <tr>
          <td>{'$10M – $100M'}</td>
-         <td>0.00%</td>
-         <td>0.0066%</td>
-         <td>0.045%</td>
-         <td>0.10%</td>
+         <td>0%</td>
+         <td>34%</td>
+         <td>25%</td>
+         <td>33.33%</td>
        </tr>
        <tr>
          <td>{'$100M – $1B'}</td>
-         <td>0.00%</td>
-         <td>0.0033%</td>
-         <td>0.03%</td>
-         <td>0.05%</td>
+         <td>0%</td>
+         <td>67%</td>
+         <td>50%</td>
+         <td>66.67%</td>
        </tr>
      </tbody>
    </table>
 
-   _* Volume Tier is in USD, trailing 30 days_
+   _* The Revenue Share Volume Tier is calculated based on aggregate U.S. dollar value of transactions, trailing 30 days._
 
    **Relay Fee Categories:**
-   - **Same token bridging**: bridging with no swap, e.g. USDC on Arbitrum to USDC on Base.
-   - **Stablecoin swaps**: includes same and cross-chain swaps between USDC, USDT, DAI, USDe and USDS.
-   - **Major token swaps**: includes same and cross-chain swaps between ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, USDC including when paired with major stablecoins (USDT, DAI, USDe and USDs).
-   - **Minor token swaps**: includes same and cross-chain swaps between any tokens not listed above, e.g. AVAX on Avalanche to Aster on Binance Smart Chain.
+   - **Same token bridging:** a token bridge transaction with the same asset and no swap. Examples:
+     - USDC on Arbitrum to USDC on Base
+   - **Same-chain wrap/unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:
+     - ETH to WETH on Ethereum
+     - SOL to WSOL on Solana
+     - POL to WPOL on Polygon
+     - BNB to WBNB on BNB Chain
+   - **Stablecoin swaps:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD. Examples:
+     - USDC to USDT on Ethereum
+     - USDC on Optimism to USDT on Solana
+   - **Major token swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME, and between any major token and any major stablecoin. Examples:
+     - ETH to WETH on Polygon
+     - ETH on Ethereum to SOL on Solana
+   - **Minor token swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:
+     - LINK to UNI on Ethereum
+     - AVAX on Avalanche to Aster on Binance Smart Chain
 
 4. **App Fees**
 
    Fees added on top of a Relay by the integrator.
 
-If you are interested in learning how app fees work, and how you can add them to your quotes please check out our [App Fees Doc](/features/app-fees).\
-\
+If you are interested in learning how app fees work, and how you can add them to your quotes please check out our [App Fees Doc](/features/app-fees).
+
 _Please note that the above fee structure applies to standard cases. In certain cases, such as route-specific campaigns or promotions, different fees may apply._
 
 ## Fees Object

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -99,7 +99,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      - USDC to USDT on Ethereum
      - USDC on Optimism to USDT on Solana
    - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME (each, a "Major Token"), and between any Major Token and any Major Stablecoin. Examples:
-     - ETH to WETH on Polygon
+     - ETH to POL on Polygon
      - ETH on Ethereum to SOL on Solana
    - **Minor swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:
      - LINK to UNI on Ethereum

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -87,7 +87,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
 
    _* The Revenue Share Volume Tier is calculated based on the aggregate U.S. dollar value of the transactions for the trailing 30 days._
 
-   **Relay Fee Categories:**
+   **Relay Transaction Types:**
    - **Same token bridging:** a token bridge transaction with the same asset and no swap. Examples:
      - USDC on Arbitrum to USDC on Base
    - **Same-chain wrap/unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -88,7 +88,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    _* The Revenue Share Volume Tier is calculated based on the aggregate U.S. dollar value of the transactions for the trailing 30 days._
 
    **Relay Transaction Types:**
-   - **Same token bridging:** a token bridge transaction with the same asset and no swap. Examples:
+   - **Token Bridging:** a token bridge transaction with the same asset and no swap. Examples:
      - USDC on Arbitrum to USDC on Base
    - **Same-chain wrap/unwrap:** a 1:1 conversion on the same chain between a native asset and its tokenized equivalent via a single smart contract. Wrapping locks the native asset and mints the wrapped token; unwrapping burns the wrapped token and releases the native asset. Examples:
      - ETH to WETH on Ethereum

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -95,13 +95,13 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      - SOL to WSOL on Solana
      - POL to WPOL on Polygon
      - BNB to WBNB on BNB Chain
-   - **Stablecoin swaps:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD (each, a "Major Stablecoin"). Examples:
+   - **Stablecoin swap:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD (each, a "Major Stablecoin"). Examples:
      - USDC to USDT on Ethereum
      - USDC on Optimism to USDT on Solana
-   - **Major swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME (each, a "Major Token"), and between any Major Token and any Major Stablecoin. Examples:
+   - **Major swap:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME (each, a "Major Token"), and between any Major Token and any Major Stablecoin. Examples:
      - ETH to POL on Polygon
      - ETH on Ethereum to SOL on Solana
-   - **Minor swaps:** same-chain or cross-chain token swaps between any pair of tokens that are not a Major Stablecoin or Major Token. Examples:
+   - **Minor swap:** same-chain or cross-chain token swaps between any pair of tokens that are not a Major Stablecoin or Major Token. Examples:
      - LINK to UNI on Ethereum
      - AVAX on Avalanche to Aster on BNB Chain
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -107,7 +107,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
 
 4. **App Fees**
 
-   Fees added on top of a Relay quote.
+   Fees added on top of a Relay quote by the integrator.
 
 If you are interested in learning how app fees work, and how you can add them to your quotes please check out our [App Fees Doc](/features/app-fees).
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -103,7 +103,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      - ETH on Ethereum to SOL on Solana
    - **Minor token swaps:** same-chain or cross-chain swaps between any tokens not listed above. Examples:
      - LINK to UNI on Ethereum
-     - AVAX on Avalanche to Aster on Binance Smart Chain
+     - AVAX on Avalanche to Aster on BNB Chain
 
 4. **App Fees**
 

--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -95,7 +95,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
      - SOL to WSOL on Solana
      - POL to WPOL on Polygon
      - BNB to WBNB on BNB Chain
-   - **Stablecoin swaps:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD. Examples:
+   - **Stablecoin swaps:** same-chain or cross-chain swaps between any pair of these stablecoins: USDC, USDC.e, USDT, USDT0, DAI, USDe, USDS, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, and PlumeUSD (each, a "Major Stablecoin"). Examples:
      - USDC to USDT on Ethereum
      - USDC on Optimism to USDT on Solana
    - **Major token swaps:** same-chain or cross-chain swaps between any pair of these tokens: ETH, WETH, BTC, WBTC, SOL, WSOL, POL, BNB, and PLUME, and between any major token and any major stablecoin. Examples:


### PR DESCRIPTION
## Summary
Significantly expanded and reorganized the fee structure documentation to provide clearer explanations of how Relay's fees work, added detailed revenue share information for API customers, and improved the categorization of different transaction types.

## Key Changes

- **Restructured fee categories**: Renamed "Relay Fees" section title to "Fee Structure" and clarified that fees apply to "token swap or bridge powered by Relay"

- **Enhanced Execution Fees explanation**: 
  - Clarified the three components: $0.02 flat fee, destination gas estimate, and origin gas estimate (gasless only)
  - Added explicit note that regular transaction users pay origin gas directly to the network, not through Relay

- **Improved Swap Fees section**: Added note about Hyperliquid's $1 activation fee that is passed through to users

- **Expanded Relay Fees documentation**:
  - Split into two tables: one showing standard fees charged to end users, and a new table showing revenue share percentages for qualified API customers
  - Added qualification requirements: API key, KYB verification, $10M+ volume threshold, and EVM wallet address
  - Clarified that revenue share cannot be used to discount the product to end users

- **Enhanced fee category definitions**:
  - Added "Same-chain wrap/unwrap" as a distinct category with examples (ETH↔WETH, SOL↔WSOL, etc.)
  - Expanded stablecoin list to include: USDC.e, USDT0, USD1, PYUSD, USDG, mUSD, USDm, USDH, pUSD, PlumeUSD
  - Added PLUME to major token swaps list
  - Provided concrete examples for each category
  - Improved formatting and clarity of category descriptions

- **Minor formatting improvements**: Fixed trailing whitespace and improved markdown consistency

## Notable Details
The documentation now clearly distinguishes between end-user fees and revenue share opportunities for API customers, with explicit qualification criteria and volume-based tiers. The expanded token lists and examples make it easier for users to determine which fee category applies to their transactions.

https://claude.ai/code/session_01JQ8XT6661N4WzF4Q7vt8WF