### PR TITLE
Fix capitalization of "Execution fee" in fees page

### DIFF
--- a/references/api/api_core_concepts/fees.mdx
+++ b/references/api/api_core_concepts/fees.mdx
@@ -12,7 +12,7 @@ In any given token swap or bridge powered by Relay, there are four potential fee
    - Destination (fill) gas estimate — always included, covers transaction fulfillment on the destination chain
    - Origin gas estimate — only included for gasless transactions, covers transaction submission on the origin chain on the user's behalf
 
-   For regular (non-gasless) transactions, the user pays origin gas directly from their own wallet to the network — it's not part of Relay's fee.
+   For regular (non-gasless) transactions, the user pays origin gas directly from their own wallet to the network — it's not part of the Execution fee.
 
 2. **Swap Fees**
 


### PR DESCRIPTION
Changes "Relay's fee" to "the Execution fee" in the execution fees section for consistency with the named fee type introduced earlier in the same paragraph.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJKErZ4iH7AyCaUrvHe5UV)_