### PR TITLE
docs(solutions): add Payment Service Providers page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -24,7 +24,8 @@
               "solutions/wallets-and-wallet-providers",
               "solutions/multichain-apps",
               "solutions/chains",
-              "solutions/commerce-and-payments"
+              "solutions/commerce-and-payments",
+              "solutions/payment-service-providers"
             ]
           },
           {

--- a/solutions/payment-service-providers.mdx
+++ b/solutions/payment-service-providers.mdx
@@ -1,0 +1,77 @@
+---
+title: "Payment Service Providers"
+description: "Accept and disburse any asset, on any chain, settled to the currency you run on"
+---
+
+Relay is onchain payments infrastructure that lets payment service providers add universal onchain acceptance and payouts through a single integration. Consumers and businesses can spend any onchain currency they hold and Relay routes, converts, and settles to your chosen asset and chain.
+
+
+<Columns cols={4}>
+  <Card title="85+ Chains" icon="link">
+    Every asset on every major network
+  </Card>
+  <Card title="< 3s Settlement" icon="bolt">
+    P50 fill time across all routes
+  </Card>
+  <Card title="$20B+" icon="chart-line">
+    Volume enabled to date
+  </Card>
+  <Card title="100M+ Txs" icon="receipt">
+    Processed across the network
+  </Card>
+</Columns>
+
+## Use Cases
+
+### Pay-ins or Commerce
+
+Accept funds in any asset on any of 85+ chains — or the same chain — and receive your settlement asset (e.g., USDC on Base or Solana). Two integration paths:
+
+**Connected or embedded wallet payments** — Use the standard [quote and deposit flow](/references/api/get-quote-v2) when your user connects a wallet. Quote, deposit, fill. Deposits are optionally [gasless](/features/gasless-execution), with [fixed or market rates](/features/price-stabilization). 
+
+**Deposit addresses** — Generate one [deposit address](/features/deposit-addresses) per order for wallet-less acceptance. Anything sent to it is routed and converted to your settlement asset automatically, with no frontend integration on the payer side. Deposit addresses also power QR and scan-to-pay for cross-chain acceptance, and are extremely valuable for centralized exchange payments. 
+
+### Disbursements
+
+Run pay-ins in reverse to send funds out — marketplace seller payouts, creator and worker disbursements, and cross-border payout — to any chain and asset from your settlement balance, through the same integration.
+
+## Compliance & Screening
+
+Relay screens every transaction in real time against multiple independent blockchain-analytics providers and a continuously maintained internal blocklist, enforcing OFAC and other global sanctions requirements. Screening covers every party to a transfer — sender, recipient, and fee recipient, plus the depositing wallet on deposit-address flows — not just a single address. A match on any party blocks the quote and fill. See [Compliance](/security/compliance) for details.
+
+## Features
+
+**[Exact-output settlement](/references/api/api_core_concepts/trade-types)** — Specify the exact amount you need to receive; Relay sizes the input. No slippage, no shortfalls.
+
+**[Price stabilization](/features/price-stabilization)** — Lock a fixed rate (e.g. 1:1) on stablecoin pairs, or sponsor fees so the user receives the full market-rate output. Removes exchange rate surprises from settlement.
+
+**[Gasless execution](/features/gasless-execution)** — Your users transact without spending gas directly. This can be used for Relay deposits or more genreally for any onchain gasless execution. 
+
+**[Fee sponsorship](/features/fee-sponsorship)** — Pay or subsidize gas or spreads on your users' behalf, and let them pay in the asset they already hold.
+
+**[App fees](/features/app-fees)** — Attach your own fee to any flow and collect it at settlement, automatically settled in USDC on Base.
+
+**[MEV protection](/security/mev-protection)** — Swaps are routed for best execution.
+
+**[Webhooks and tracking](/references/api/api_guides/webhooks)** — Lifecycle events are pushed to your backend (HMAC-signed), and every payment carries a `requestId` for reconciliation.
+
+**Reliability** — 99.9%+ fill success with sub-3-second settlement on supported routes.
+
+## Pricing
+
+Relay's cost is transparent in every quote. The `expandedPriceImpact` object breaks each payment into its execution, swap, and Relay fee components, plus any app fee you add — so your finance team can model unit economics exactly. Integrators above a volume threshold qualify for a revenue share on the Relay fee. See [Fee Structure](/references/api/api_core_concepts/fees).
+
+
+## Security
+
+Relay's contracts are independently audited, and the protocol runs an ongoing bug bounty. Review the [Contract Audits](/security/contract-audits) and [Bug Bounty](/security/bounties) before you integrate.
+
+
+## Get Started
+
+Add cross-chain pay-ins and disbursements to your platform through a single integration. The [Quote API](/references/api/get-quote-v2) is the core endpoint behind both flows.
+
+- **[Quickstart Guide](/references/api/quickstart)** — make your first cross-chain transaction.
+- **[Quote API reference](/references/api/get-quote-v2)** — the core endpoint behind pay-ins and disbursements.
+- **[Deposit Addresses](/features/deposit-addresses)** — wallet-less acceptance.
+- **[Contact us](https://forms.gle/XNeELYavjwoJwPEf7)** — discuss your corridors, volumes, and settlement requirements.


### PR DESCRIPTION
New PSP solutions page (pay-ins/commerce, disbursements, compliance screening, features, pricing), modeled on the commerce-and-payments page and wired into the Solutions nav.