### PR TITLE
docs: document EXACT_OUTPUT support for bridging

### DIFF
--- a/references/api/api_core_concepts/trade-types.mdx
+++ b/references/api/api_core_concepts/trade-types.mdx
@@ -20,7 +20,7 @@ We recommend using `EXPECTED_OUTPUT` for when an exact output amount is not nece
 
 ## Exact Output
 
-The third supported type is `EXACT_OUTPUT`. In this order type, the user specifies exactly how much of the output currency they want to receive from the swap or bridge. 
-The user is told how much of the origin token this will require to receive exactly the output amount. If the exact requested amount out cannot be filled, the request is failed and the user is refunded on origin. 
+The third supported type is `EXACT_OUTPUT`. In this order type, the user specifies exactly how much of the output currency they want to receive from the swap, bridge, or cross-chain call.
+The user is told how much of the origin token this will require to receive exactly the output amount. If the exact requested amount out cannot be filled, the request is failed and the user is refunded on origin.
 This trade type automatically accounts for any associated fees including relay fees, app fees, and gas fees.
-We recommend using `EXACT_OUTPUT` for destination calls that require a precise output amount, like minting with an exact ERC20 amount. Destination calls also support `EXACT_INPUT` when you want to cap spend and accept a variable output.
+We recommend using `EXACT_OUTPUT` when a precise output amount is required — for example, bridging an exact amount to a destination address, guaranteeing a merchant receives a specific payment amount, or executing a destination call that requires a fixed input such as minting with an exact ERC20 amount. Destination calls also support `EXACT_INPUT` when you want to cap spend and accept a variable output.

--- a/references/api/api_guides/bridging-integration-guide.mdx
+++ b/references/api/api_guides/bridging-integration-guide.mdx
@@ -23,8 +23,14 @@ While not mandatory for integration, doing the following will improve the UX for
     ## Get a Quote
     Every action in Relay starts with a Quote, this includes bridging. The quote provides all necessary information including fees, transaction data, and execution steps. Use the [quote endpoint](/references/api/get-quote-v2) to request a bridge quote.
 
+    Relay supports three [trade types](/references/api/api_core_concepts/trade-types) for bridging:
+
+    - **`EXACT_INPUT`** — specify the amount you want to send; the output amount may vary based on fees and slippage.
+    - **`EXPECTED_OUTPUT`** — specify the approximate amount you want to receive; the input amount is calculated accordingly and the output may vary slightly due to slippage.
+    - **`EXACT_OUTPUT`** — specify the exact amount you want to receive; the input amount is calculated accordingly. If the exact output cannot be filled, the request fails and the user is refunded on the origin chain.
+
     <CodeGroup>
-    ```bash Request
+    ```bash EXACT_INPUT
     curl -X POST "https://api.relay.link/quote/v2" \
       -H "Content-Type: application/json" \
       -d '{
@@ -35,6 +41,19 @@ While not mandatory for integration, doing the following will improve the UX for
         "destinationCurrency": "0x0000000000000000000000000000000000000000",
         "amount": "100000000000000000",
         "tradeType": "EXACT_INPUT"
+      }'
+    ```
+    ```bash EXACT_OUTPUT
+    curl -X POST "https://api.relay.link/quote/v2" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "user": "0x03508bb71268bba25ecacc8f620e01866650532c",
+        "originChainId": 1,
+        "destinationChainId": 8453,
+        "originCurrency": "0x0000000000000000000000000000000000000000",
+        "destinationCurrency": "0x0000000000000000000000000000000000000000",
+        "amount": "100000000000000000",
+        "tradeType": "EXACT_OUTPUT"
       }'
     ```
     ```json Response expandable


### PR DESCRIPTION
## Summary

- **`trade-types.mdx`**: Broadens the `EXACT_OUTPUT` section to include bridging and payment use cases. Previously, the recommendation was scoped exclusively to destination calls (e.g. minting with an exact ERC20 amount). Engineering confirmed `EXACT_OUTPUT` is also supported for plain bridging.
- **`bridging-integration-guide.mdx`**: Adds an explicit trade type selection guide at the top of the "Get a Quote" step, with a description of all three supported trade types (`EXACT_INPUT`, `EXPECTED_OUTPUT`, `EXACT_OUTPUT`) and a second curl example showing an `EXACT_OUTPUT` bridge quote request alongside the existing `EXACT_INPUT` example.

## What changed and why

`EXACT_OUTPUT` was previously described only as a feature for cross-chain destination calls. This left a documentation gap where developers using the bridging integration guide had no visibility into `EXACT_OUTPUT` as an option, and the trade-types reference page actively directed readers away from using it for bridges. The deposit addresses page compounds this by noting `EXACT_OUTPUT` is only supported on strict deposit addresses, which could be misread as a global restriction rather than one scoped to the deposit address flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve31cBC5xFMZvJy9X8BEKL)_