### PR TITLE
docs: fix `useWalletClient` usage

### DIFF
--- a/references/relay-kit/sdk/actions/execute.mdx
+++ b/references/relay-kit/sdk/actions/execute.mdx
@@ -21,7 +21,7 @@ import { useWalletClient } from 'wagmi'
 
 ...
 
-const wallet = useWalletClient()
+const { data: wallet } = useWalletClient()
 
 const options = ... //define this based on getQuote options
 


### PR DESCRIPTION
## Changes

* Updated the `execute` example to destructure `data` from `useWalletClient()` instead of passing the full hook result.
* The `execute()` action expects a `WalletClient`, while `useWalletClient()` returns a hook result object with the client available under `data`. 

This change aligns the example with the expected API and keeps it consistent with the existing [`getQuote`](https://github.com/relayprotocol/relay-docs/blob/main/references/relay-kit/sdk/actions/getQuote.mdx#native-bridge-example) documentation, which already uses the same pattern.