### PR TITLE
docs: update Get Quote API reference to v2

### DIFF
--- a/features/fee-sponsorship.mdx
+++ b/features/fee-sponsorship.mdx
@@ -42,7 +42,7 @@ Once your app balance is funded, you can sponsor transactions by including speci
 
 ### Sponsorship Parameters
 
-Add these parameters to your [Get Quote](/references/api/get-quote) API request:
+Add these parameters to your [Get Quote](/references/api/get-quote-v2) API request:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -257,6 +257,6 @@ For more details on the fee structure, see [Relay Fees](/references/api/api_core
 
 - [App Fees](/features/app-fees) — Learn how to collect fees from your users
 - [Get App Fee Balances](/references/api/get-app-fee-balances) — API reference for checking balances
-- [Get Quote](/references/api/get-quote) — API reference for quote requests
+- [Get Quote](/references/api/get-quote-v2) — API reference for quote requests
 - [Relay Fees](/references/api/api_core_concepts/fees) — Understanding Relay's fee structure
 - [Solana Support](/references/api/api_guides/solana) — Guide to depositing and withdrawing on Solana


### PR DESCRIPTION
Updated the Get Quote API reference link in the Fee Sponsorship documentation.

- The old `/quote` method is marked as **deprecated** in the official Relay documentation
- The current active method is `/quote/v2`, which all links now point to
- Documentation users now get accurate and supported information