### PR TITLE
docs(api-keys): revise rate limit copy

### DIFF
--- a/references/api/api-keys.mdx
+++ b/references/api/api-keys.mdx
@@ -1,11 +1,9 @@
 ---
 title: "API keys and Rate Limits"
-description: "Create API keys in the Relay Dashboard to authenticate requests and raise your rate limits"
+description: "Create API keys in the Relay Dashboard to authenticate requests and manage your rate limits"
 ---
 
-Relay enforces rate limits to keep the platform reliable for every integrator. Default limits apply to unauthenticated traffic; an API key raises those limits and attributes each request to your account.
-
-You manage keys in the [Relay Dashboard](https://dashboard.relay.link) — create new keys, rotate existing ones, and inspect individual requests.
+Relay enforces rate limits to keep the platform reliable for every integrator. You manage API keys in the [Relay Dashboard](https://dashboard.relay.link) — create new API keys, rotate existing ones, and inspect individual requests. Default limits listed below apply to self-minted API keys.
 
 ## Creating an API key
 
@@ -30,9 +28,9 @@ The [Relay Dashboard](https://dashboard.relay.link) is also where you observe wh
 
 When debugging a specific transaction, paste the `requestId` from your application into the dashboard's search to jump straight to the matching record.
 
-## Default Rate Limits (no API key)
+## Default Rate Limits
 
-The following limits apply to unauthenticated requests:
+The following limits apply per API key:
 
 | Endpoint               | Limit                   |
 | ---------------------- | ----------------------- |
@@ -41,9 +39,9 @@ The following limits apply to unauthenticated requests:
 | `/transactions/status` | 200 requests per minute |
 | Other endpoints        | 200 requests per minute |
 
-## API key Rate Limits
+## Elevated Rate Limits
 
-Authenticated requests get higher limits, applied per key:
+Higher limits are available on request, applied per key:
 
 | Endpoint               | Limit                   |
 | ---------------------- | ----------------------- |
@@ -52,7 +50,7 @@ Authenticated requests get higher limits, applied per key:
 | `/transactions/status` | 10 requests per second  |
 | Other endpoints        | 200 requests per minute |
 
-API keys are recommended for server-side production integrations and higher-throughput use cases.
+To request higher limits, get in touch through the support widget in the [Relay Dashboard](https://dashboard.relay.link).
 
 ## How to Use an API key
 

--- a/references/api/api-keys.mdx
+++ b/references/api/api-keys.mdx
@@ -56,7 +56,7 @@ To request higher limits, get in touch through the support widget in the [Relay 
 
 ### HTTP requests
 
-Pass the key in the request headers on every call where you want elevated limits:
+Pass the key in the request headers on every request:
 
 ```
 x-api-key: YOUR_API_KEY
@@ -95,7 +95,7 @@ const quote = await getClient()?.actions.getQuote(quoteParams, undefined, {
 
 ### Proxy API
 
-If you're calling the SDK from the browser, stand up a proxy that appends the key server-side and point `baseApiUrl` at it. This keeps the key out of client bundles while preserving elevated limits.
+If you're calling the SDK from the browser, stand up a proxy that appends the key server-side and point `baseApiUrl` at it. This keeps the key out of client bundles while preserving your key's rate limits.
 
 ```typescript
 import {

--- a/references/api/api-keys.mdx
+++ b/references/api/api-keys.mdx
@@ -3,7 +3,7 @@ title: "API keys and Rate Limits"
 description: "Create API keys in the Relay Dashboard to authenticate requests and manage your rate limits"
 ---
 
-Relay enforces rate limits to keep the platform reliable for every integrator. You manage API keys in the [Relay Dashboard](https://dashboard.relay.link) — create new API keys, rotate existing ones, and inspect individual requests. Default limits listed below apply to self-minted API keys.
+Relay enforces rate limits to keep the platform reliable for every integrator. You manage API keys in the [Relay Dashboard](https://dashboard.relay.link) — create new API keys, rotate existing ones, and inspect individual requests. Default limits listed below apply to self-serve API keys.
 
 ## Creating an API key
 

--- a/references/api/api_guides/websockets.mdx
+++ b/references/api/api_guides/websockets.mdx
@@ -31,15 +31,13 @@ Refer to the guide below on how to integrate the websocket into your application
 
 ## **Authentication**
 
-The Websocket Service is available for anyone with strict rate limits. For customers with an API key it can be used for authentication for higher rate limits, the service is available at the following URL `wss://ws.relay.link`
+The Websocket Service uses an API key for authentication and is available at the following URL `wss://ws.relay.link`
 
 To connect using an API key, provide your API key as a query param in the connection url:
 
 ```
 const wss = new ws(`wss://ws.relay.link?apiKey=${YOUR_API_KEY}`);
 ```
-
-<Tip>Authentication is generally not required in client-side applications.</Tip>
 
 <Warning>
 **The websocket server needs to restart to deploy updates**

--- a/references/api/quickstart.mdx
+++ b/references/api/quickstart.mdx
@@ -23,7 +23,7 @@ Follow this 5-step flow to integrate Relay into your application:
 
     <Callout icon="key" color="#4615C8">
     ### API key Provisioning
-    Create an API key in the [Relay Dashboard](https://dashboard.relay.link) to raise your rate limits. <br/>
+    Create an API key in the [Relay Dashboard](https://dashboard.relay.link). <br/>
     See [API keys and Rate Limits](/references/api/api-keys) for usage and limits.
     </Callout>
 

--- a/snippets/GetAnApiKey.mdx
+++ b/snippets/GetAnApiKey.mdx
@@ -1,3 +1,3 @@
 <Tip>
-Create an API key in the [Relay Dashboard](https://dashboard.relay.link) to raise your rate limits.
+Create an API key in the [Relay Dashboard](https://dashboard.relay.link).
 </Tip>


### PR DESCRIPTION
## What Changed

Reframes the API key rate-limit docs so a key reads as self-minted in the [Relay Dashboard](https://dashboard.relay.link), with the default limits applying to those keys and higher limits available on request through the Dashboard support widget. Renames the two rate-limit sections on `references/api/api-keys.mdx` to **Default Rate Limits** and **Elevated Rate Limits** (limit values unchanged), and drops the same "raise your rate limits" / "available to anyone" framing from the quickstart, the shared `GetAnApiKey` snippet, and the websockets guide.

## Why

The copy implied any API key inherently grants higher limits, and that the API is usable unauthenticated at a baseline rate. In reality a newly self-minted key starts on the default limits — the same numbers previously labeled "no API key" — and higher limits are granted on request. Pedro flagged this after the developer-dashboard docs shipped in #369.

## Impact

Documentation only — no API or SDK behavior changes. Anchor slugs on the API keys page change (`#default-rate-limits-no-api-key` → `#default-rate-limits`, `#api-key-rate-limits` → `#elevated-rate-limits`); a repo-wide check found no internal links to the old anchors.

## Related Context

- Refs: INT2-929
- Refs: https://relayprotocol.slack.com/archives/C04EBEGJV2M/p1784297558289219
- Prior PR: #369 (developer dashboard docs)

## Testing

Static review plus a `grep` sweep confirming no residual "to raise your rate limits" / "available for anyone" / "(no API key)" / "generally not required" phrasing remains. The Mintlify CLI isn't installed in this environment, so the rendered page was **not** previewed live; MDX structure (tables, `<Tip>`/`<Warning>`/`<Callout>` tags, frontmatter) was verified by inspection.
